### PR TITLE
Relativize URLs

### DIFF
--- a/processors.go
+++ b/processors.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"hash/adler32"
+	"io"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -11,8 +13,6 @@ import (
 	"strings"
 	"text/template"
 	"time"
-	"hash/adler32"
-	"io"
 )
 
 type Processor struct {


### PR DESCRIPTION
Hi,
this is a small patch that relativize absolute URLs during ProcessMarkdown, just before doing the actual markdown processing.

Thanks to that, a link such as `[my link](/index.html)` will always point to the right place.

This is my first time writing go code, feel free to give me feedback !
