### PR TITLE
Tiny fix for ineffective --processors flag.

### DIFF
--- a/gostatic.go
+++ b/gostatic.go
@@ -54,6 +54,7 @@ func main() {
 	}
 
 	if *showProcessors {
+		InitProcessors()
 		ProcessorSummary()
 		return
 	}


### PR DESCRIPTION
This flag didn't have any effect because InitProcessors() is not called
before calling ProcessorSummary().
