### PR TITLE
Convert windows path separators to unix style, otherwise rules wouldn't ...

### DIFF
--- a/page.go
+++ b/page.go
@@ -49,6 +49,9 @@ func NewPage(site *Site, path string) *Page {
 	relpath, err := filepath.Rel(site.Source, path)
 	errhandle(err)
 
+	// convert windows path separators to unix style
+	relpath = strings.Replace(relpath, "\\", "/", -1)
+
 	pattern, rule := site.Rules.MatchedRule(relpath)
 
 	page := &Page{
@@ -228,7 +231,7 @@ func (pages PageSlice) Last() *Page     { return pages.Get(len(pages) - 1) }
 func (pages PageSlice) Prev(cur *Page) *Page {
 	for i, page := range pages {
 		if page == cur {
-			if i == pages.Len() - 1 {
+			if i == pages.Len()-1 {
 				return nil
 			}
 			return pages[i+1]


### PR DESCRIPTION
...match

Hi,
I had problems to get the example working on windows. Problem was that on windows a filepath has different path separators which prevent the system from matching rules.
This patch will just convert backslashes in forward slashes...

best,
flicaflow
