### PR TITLE
Watch config.Source instead of config.Output

### DIFF
--- a/watch.go
+++ b/watch.go
@@ -31,7 +31,7 @@ func Watcher(config *SiteConfig) (chan string, error) {
 		}
 	}()
 
-	filepath.Walk(config.Output, watchAll(watcher))
+	filepath.Walk(config.Source, watchAll(watcher))
 	for _, path := range config.Templates {
 		watcher.Watch(path)
 	}


### PR DESCRIPTION
Fixes an issue which caused the watcher to not trigger re-builds, as it
was incorrectly watching the output folder.
