### PR TITLE
Expose Markdown as 'markdown' template func

### DIFF
--- a/template_funcs.go
+++ b/template_funcs.go
@@ -105,4 +105,5 @@ var TemplateFuncMap = template.FuncMap{
 	"split":          strings.Split,
 	"contains":       Contains,
 	"paginator":      CurrentPaginator,
+	"markdown":       Markdown,
 }


### PR DESCRIPTION
For use with `.Raw`, e.g.

```
{{ markdown .Raw }}
```
