### PR TITLE
Update example site feed for 2.x

### DIFF
--- a/example.go
+++ b/example.go
@@ -144,7 +144,7 @@ var ExampleFeed = `
   <link href="{{ .Site.Other.Url }}{{ .Url }}" rel="alternate"></link>
   <content type="html">
     {{/* .Process runs here in case only feed changed */}}
-    {{ with cut .Process.Content "<section>" "</section>" }}
+    {{ with cut "<section>" "</section>" .Process.Content }}
       {{ html . }}
     {{ end }}
   </content>


### PR DESCRIPTION
I've updated the example feed generated to use the new parameter orders for the cut function.