### PR TITLE
Error checking to prevent copy failures

### DIFF
--- a/lib/site.go
+++ b/lib/site.go
@@ -4,6 +4,7 @@
 package gostatic
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -167,7 +168,9 @@ func (site *Site) Render() {
 		errhandle(err)
 
 		_, err = page.Render()
-		errhandle(err)
+		if err != nil {
+			errhandle(fmt.Errorf("Unable to render page '%s': %v", page.Source, err))
+		}
 	}
 }
 

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -122,6 +122,10 @@ func Capitalize(s string) string {
 func CopyFile(srcPath, dstPath string) (n int64, err error) {
 	fstat, err := os.Lstat(srcPath)
 
+	if err != nil {
+		return 0, err
+	}
+
 	if fstat.Mode()&os.ModeSymlink != 0 {
 		target, err := os.Readlink(srcPath)
 		if err != nil {

--- a/lib/version.go
+++ b/lib/version.go
@@ -1,5 +1,5 @@
 package gostatic
 
 const (
-	VERSION = "2.2"
+	VERSION = "2.3"
 )


### PR DESCRIPTION
So I configured Vim to use nobackup and noswap files. It looks like Vim writes these files nonetheless (files starting with a tilde character), and deletes them very quickly. However, if gostatic found a change in the src directory, it lists the ~ files as well, wanting to copy them, but they are deleted already. This resulted in a panic:

 	panic: runtime error: invalid memory address or nil pointer dereference
	[signal 0xb code=0x1 addr=0x1c pc=0x80ddea7]

	goroutine 20 [running]:
	github.com/piranha/gostatic/lib.CopyFile(0x188b8da0, 0xd, 0x188b8dc0, 0xe, 0x0, 0x0, 0xb6b5c990, 0x188bed80)
			/home/krpors/development/go/src/github.com/piranha/gostatic/lib/utils.go:130 +0x2e7
	github.com/piranha/gostatic/lib.(*Page).Render(0x1888c510, 0x0, 0x0, 0x0, 0x0)
			/home/krpors/development/go/src/github.com/piranha/gostatic/lib/page.go:235 +0xae
	github.com/piranha/gostatic/lib.(*Site).Render(0x18757d50)
			/home/krpors/development/go/src/github.com/piranha/gostatic/lib/site.go:169 +0x33e
	github.com/piranha/gostatic/lib.Watch.func1(0x187de140, 0x187de000, 0x1870f480)
			/home/krpors/development/go/src/github.com/piranha/gostatic/lib/site.go:76 +0xf1
	created by github.com/piranha/gostatic/lib.Watch
			/home/krpors/development/go/src/github.com/piranha/gostatic/lib/site.go:79 +0xb7

So, summarized:
* Vim writes a ~ file
* Gostatic sees change
* Gostatic lists files, sees ~ file
* Copy ~ file to destination
* Lstat fails because Vim deleted it
* Panic

This pull request fixes that by spitting out an error, instead of panicking. Also added a nicer error message when an invalid configuration file is found. It resulted in a panic.