### PR TITLE
processors: add ignorefuture processor

### DIFF
--- a/processors/default.go
+++ b/processors/default.go
@@ -18,4 +18,5 @@ var DefaultProcessors = gostatic.ProcessorMap{
 	"rename":                 NewRenameProcessor(),
 	"external":               NewExternalProcessor(),
 	"ignore":                 NewIgnoreProcessor(),
+	"ignorefuture":           NewIgnoreFutureProcessor(),
 }

--- a/processors/ignorefuture.go
+++ b/processors/ignorefuture.go
@@ -1,0 +1,28 @@
+package processors
+
+import (
+	gostatic "github.com/piranha/gostatic/lib"
+	"time"
+)
+
+type IgnoreFutureProcessor struct {
+}
+
+func NewIgnoreFutureProcessor() *IgnoreFutureProcessor {
+	return &IgnoreFutureProcessor{}
+}
+
+func (p *IgnoreFutureProcessor) Process(page *gostatic.Page, args []string) error {
+	if time.Now().Before(page.Date) {
+		return ProcessIgnore(page, args)
+	}
+	return nil
+}
+
+func (p *IgnoreFutureProcessor) Description() string {
+	return "ignore file dated in future"
+}
+
+func (p *IgnoreFutureProcessor) Mode() int {
+	return gostatic.Pre
+}


### PR DESCRIPTION
A new processor that can be used to ignore files that are dated in the future. Lets you schedule blog posts ahead of time.