### PR TITLE
Added UTF-8 with BOM support #79

### DIFF
--- a/lib/page.go
+++ b/lib/page.go
@@ -4,6 +4,7 @@
 package gostatic
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -82,6 +83,11 @@ func (page *Page) Raw() string {
 	if !page.wasread {
 		data, err := ioutil.ReadFile(page.FullPath())
 		errhandle(err)
+
+		if bytes.HasPrefix(data, []byte{0xEF, 0xBB, 0xBF}) {
+			data = data[3:]
+		}
+
 		page.raw = string(data)
 		page.wasread = true
 		debug("Page '%s' was read, is of length %d\n", page.FullPath(), len(page.raw))


### PR DESCRIPTION
Ones again.
This time I checked the solution on different files in different encodings. Works in case of UTF-8 or UTF-8 with BOM. If we have BOM characters we just remove it.
This solution do not work with another encodings, such UTF-16 for example.