### PR TITLE
Setup go mod for gostatic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/piranha/gostatic
+
+require (
+	github.com/jessevdk/go-flags v1.4.0
+	github.com/russross/blackfriday v1.5.2
+	github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 // indirect
+	golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b // indirect
+	gopkg.in/fsnotify.v1 v1.4.7
+	gopkg.in/yaml.v2 v2.2.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
+github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/russross/blackfriday v2.0.0+incompatible h1:cBXrhZNUf9C+La9/YpS+UHpUT8YD6Td9ZMSU9APFcsk=
+github.com/russross/blackfriday v2.0.0+incompatible/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 h1:/vdW8Cb7EXrkqWGufVMES1OH2sU9gKVb2n9/1y5NMBY=
+github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b h1:MQE+LT/ABUuuvEZ+YQAMSXindAdUh7slEmAkup74op4=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
+gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
+gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
I tried to build gostatic, but get errors:

```$ go get ./...
go: finding github.com/shurcooL/sanitized_anchor_name latest
go: finding golang.org/x/sys/unix latest
go: finding golang.org/x/sys latest
# github.com/piranha/gostatic/lib
lib/utils.go:81:11: undefined: blackfriday.HTML_USE_SMARTYPANTS
lib/utils.go:82:11: undefined: blackfriday.HTML_SMARTYPANTS_FRACTIONS
lib/utils.go:83:14: undefined: blackfriday.HtmlRenderer
lib/utils.go:87:9: undefined: blackfriday.EXTENSION_NO_INTRA_EMPHASIS
lib/utils.go:88:9: undefined: blackfriday.EXTENSION_TABLES
lib/utils.go:89:9: undefined: blackfriday.EXTENSION_FENCED_CODE
lib/utils.go:90:9: undefined: blackfriday.EXTENSION_AUTOLINK
lib/utils.go:91:9: undefined: blackfriday.EXTENSION_STRIKETHROUGH
lib/utils.go:92:9: undefined: blackfriday.EXTENSION_SPACE_HEADERS
lib/utils.go:93:9: undefined: blackfriday.EXTENSION_FOOTNOTES
lib/utils.go:93:9: too many errors
```

Because `russross/blackfriday` got new version 2.0.1, when API was changed.

I think, we need to lock all version for libraries, what we use currently. For this we can use go modules:

```$ go mod init
go: creating new go.mod: module github.com/piranha/gostatic

$ go get ./...
go: finding github.com/shurcooL/sanitized_anchor_name latest
go: finding golang.org/x/sys/unix latest
go: finding golang.org/x/sys latest
# github.com/piranha/gostatic/lib
lib/utils.go:81:11: undefined: blackfriday.HTML_USE_SMARTYPANTS
lib/utils.go:82:11: undefined: blackfriday.HTML_SMARTYPANTS_FRACTIONS
lib/utils.go:83:14: undefined: blackfriday.HtmlRenderer
lib/utils.go:87:9: undefined: blackfriday.EXTENSION_NO_INTRA_EMPHASIS
lib/utils.go:88:9: undefined: blackfriday.EXTENSION_TABLES
lib/utils.go:89:9: undefined: blackfriday.EXTENSION_FENCED_CODE
lib/utils.go:90:9: undefined: blackfriday.EXTENSION_AUTOLINK
lib/utils.go:91:9: undefined: blackfriday.EXTENSION_STRIKETHROUGH
lib/utils.go:92:9: undefined: blackfriday.EXTENSION_SPACE_HEADERS
lib/utils.go:93:9: undefined: blackfriday.EXTENSION_FOOTNOTES
lib/utils.go:93:9: too many errors

$ cat go.mod
module github.com/piranha/gostatic

require (
	github.com/jessevdk/go-flags v1.4.0
	github.com/russross/blackfriday v2.0.0+incompatible
	github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 // indirect
	golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b // indirect
	gopkg.in/fsnotify.v1 v1.4.7
	gopkg.in/yaml.v2 v2.2.1
)
```

Change version blackfriday to 1.5.2 (last version in 1 version):

```$ cat go.mod
module github.com/piranha/gostatic

require (
	github.com/jessevdk/go-flags v1.4.0
	github.com/russross/blackfriday v1.5.2
	github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95 // indirect
	golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b // indirect
	gopkg.in/fsnotify.v1 v1.4.7
	gopkg.in/yaml.v2 v2.2.1
)

$ go get ./...

$ go build
```

After this changes we can build the same binary.

I don't know, should we get all dependencies to vendor directory, or not. In this pull request we only lock dependencies version. But if you need to get all dependencies we can use command:
`go mod vendor`

And commit new folder `vendor`.

This pull should resolve #45