### PR TITLE
Fixed relative path generation for index URLs

### DIFF
--- a/lib/page.go
+++ b/lib/page.go
@@ -146,6 +146,9 @@ func (page *Page) Rel(path string) string {
 	if root == "" {
 		root = "./"
 	}
+	if len(path) == 0 {
+		return root
+	}
 	if path[0] == '/' {
 		return root + path[1:]
 	}


### PR DESCRIPTION
Overview of the bug: if one want's to do something like `{{ .Site.Pages.BySource "index.md" | .UrlTo }}` and the resulting URL will be `index.html`, `Page.Url` will strip the `index.html` part (especially in the top-level directory) and return an empty string (line 128)… which will break on `if path[0] == '/' {` on line 152 as `path` will have no `[0]` element.

Example error: `executing "page" at <.UrlTo>: error calling UrlTo: runtime error: index out of range [0] with length 0`