### PR TITLE
Allow for use of absolute paths in gostatic -i.

### DIFF
--- a/gostatic.go
+++ b/gostatic.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	flags "github.com/jessevdk/go-flags"
 	gostatic "github.com/piranha/gostatic/lib"
@@ -80,7 +81,13 @@ func main() {
 	if opts.InitExample != nil {
 		target, _ := os.Getwd()
 		if len(*opts.InitExample) > 0 {
-			target = filepath.Join(target, *opts.InitExample)
+			// If an absolute path was given, use verbatim. Otherwise rebase path
+			// on top of current working directory.
+			if strings.HasPrefix(*opts.InitExample, "/") {
+			        target = *opts.InitExample
+			} else {
+			        target = filepath.Join(target, *opts.InitExample)
+			}
 		}
 		gostatic.WriteExample(target)
 		return


### PR DESCRIPTION
Currently the path given by the user is always appended to the CWD. This
change allows specifying an absolute directory, in case the CWD is not
controlled by the user, or it makes sense to specify an absolute path
anyway.

Tested manually two cases cases (-i relative, -i /tmp/absolute). The
code hints at the possibility of a third case (-i/--init without a
parameter that would just use the current working directory as the
target), but I can't tell how to use that.