### PR TITLE
Added dir and base path functions to templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,10 @@ expands on that a bit:
 
 - `some <x> <x> <x>....` - returns first non-nil value as a string
 
+- `dir <path>` - returns all but the last element of a path (same as [filepath.Dir](https://golang.org/pkg/path/filepath/#Dir))
+
+- `base <path>` - returns the last element of a path (same as [filepath.Base](https://golang.org/pkg/path/filepath/#Base))
+
 ### Page interface
 
 - `.Site` - global [site object](#site-interface).

--- a/lib/template_funcs.go
+++ b/lib/template_funcs.go
@@ -249,6 +249,14 @@ func Some(strs ...interface{}) string {
 	return ""
 }
 
+func Dir(value string) string {
+	return filepath.Dir(value)
+}
+
+func Base(value string) string {
+	return filepath.Base(value)
+}
+
 // TemplateFuncMap contains the mapping of function names and their corresponding
 // Go functions, to be used within templates.
 var TemplateFuncMap = template.FuncMap{
@@ -276,4 +284,6 @@ var TemplateFuncMap = template.FuncMap{
 	"count":          Count,
 	"reading_time":   ReadingTime,
 	"some":           Some,
+	"dir":            Dir,
+	"base":           Base,
 }


### PR DESCRIPTION
This would greatly help when creating the paths for links, for example:

```
<a href="{{ dir .Url }}">↑ Go up a directory</a>
```